### PR TITLE
M1: MVP animation systems

### DIFF
--- a/public/projects/leafflow-cover.svg
+++ b/public/projects/leafflow-cover.svg
@@ -1,0 +1,11 @@
+<svg width="800" height="450" viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g-leafflow" x1="0" y1="225" x2="800" y2="225" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="50%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#g-leafflow)"/>
+  <text x="400" y="225" text-anchor="middle" dominant-baseline="middle" font-family="Geist, Inter, system-ui, sans-serif" font-size="48" font-weight="600" fill="#f5f5f7">LeafFlow</text>
+</svg>

--- a/public/projects/movienest-cover.svg
+++ b/public/projects/movienest-cover.svg
@@ -1,0 +1,10 @@
+<svg width="800" height="450" viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g-movienest" x1="800" y1="0" x2="0" y2="450" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#38bdf8"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#g-movienest)"/>
+  <text x="400" y="225" text-anchor="middle" dominant-baseline="middle" font-family="Geist, Inter, system-ui, sans-serif" font-size="48" font-weight="600" fill="#f5f5f7">MovieNest</text>
+</svg>

--- a/public/projects/phoneshop-cover.svg
+++ b/public/projects/phoneshop-cover.svg
@@ -1,0 +1,10 @@
+<svg width="800" height="450" viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g-phoneshop" x1="0" y1="0" x2="0" y2="450" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#g-phoneshop)"/>
+  <text x="400" y="225" text-anchor="middle" dominant-baseline="middle" font-family="Geist, Inter, system-ui, sans-serif" font-size="48" font-weight="600" fill="#f5f5f7">PhoneShop</text>
+</svg>

--- a/public/projects/techcart-cover.svg
+++ b/public/projects/techcart-cover.svg
@@ -1,0 +1,10 @@
+<svg width="800" height="450" viewBox="0 0 800 450" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g-techcart" x1="0" y1="0" x2="800" y2="450" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#38bdf8"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#g-techcart)"/>
+  <text x="400" y="225" text-anchor="middle" dominant-baseline="middle" font-family="Geist, Inter, system-ui, sans-serif" font-size="48" font-weight="600" fill="#f5f5f7">TechCart</text>
+</svg>

--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -1,0 +1,54 @@
+const GITHUB_USER = "Pravin671231";
+
+export interface GithubStats {
+  repos: number;
+  followers: number;
+  totalStars: number;
+  error?: boolean;
+}
+
+interface GithubRepo {
+  stargazers_count: number;
+}
+
+interface GithubUser {
+  public_repos: number;
+  followers: number;
+}
+
+export async function GET() {
+  const headers: HeadersInit = process.env.GITHUB_TOKEN
+    ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+    : {};
+
+  try {
+    const [userRes, reposRes] = await Promise.all([
+      fetch(`https://api.github.com/users/${GITHUB_USER}`, {
+        headers,
+        next: { revalidate: 3600 },
+      }),
+      fetch(`https://api.github.com/users/${GITHUB_USER}/repos?per_page=100`, {
+        headers,
+        next: { revalidate: 3600 },
+      }),
+    ]);
+
+    if (!userRes.ok || !reposRes.ok) {
+      throw new Error("GitHub API request failed");
+    }
+
+    const user: GithubUser = await userRes.json();
+    const repos: GithubRepo[] = await reposRes.json();
+    const totalStars = repos.reduce((sum, repo) => sum + (repo.stargazers_count ?? 0), 0);
+
+    const stats: GithubStats = {
+      repos: user.public_repos,
+      followers: user.followers,
+      totalStars,
+    };
+    return Response.json(stats);
+  } catch {
+    const fallback: GithubStats = { repos: 0, followers: 0, totalStars: 0, error: true };
+    return Response.json(fallback);
+  }
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from "next/navigation";
+import { ProjectCaseStudy } from "@/components/projects/ProjectCaseStudy";
+import { projects } from "@/data/projects";
+
+export function generateStaticParams() {
+  return projects.map((project) => ({ slug: project.slug }));
+}
+
+export default async function ProjectPage({ params }: PageProps<"/projects/[slug]">) {
+  const { slug } = await params;
+  const project = projects.find((p) => p.slug === slug);
+
+  if (!project) {
+    notFound();
+  }
+
+  return <ProjectCaseStudy project={project} />;
+}

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { motion, type Variants } from "motion/react";
+import Link from "next/link";
+import { useCursor } from "@/context/CursorContext";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { DURATION_FAST } from "@/lib/motion";
+import type { Project } from "@/data/projects";
+import { ProjectPreview } from "./ProjectPreview";
+
+const tagContainerVariants: Variants = {
+  rest: {},
+  hover: { transition: { staggerChildren: 0.05 } },
+};
+
+const tagVariants: Variants = {
+  rest: { opacity: 0.6, y: 0 },
+  hover: { opacity: 1, y: -2, transition: { duration: DURATION_FAST } },
+};
+
+export function ProjectCard({ project, index }: { project: Project; index: number }) {
+  const { setCursor } = useCursor();
+  const canHover = useMediaQuery("(hover: hover) and (pointer: fine)");
+
+  return (
+    <motion.div
+      initial="rest"
+      whileHover={canHover ? "hover" : undefined}
+      onMouseEnter={() => canHover && setCursor("view")}
+      onMouseLeave={() => canHover && setCursor("default")}
+      className="group block overflow-hidden rounded-lg border border-border bg-bg-elevated"
+    >
+      <Link href={`/projects/${project.slug}`} className="block">
+        <ProjectPreview project={project} />
+        <div className="p-6">
+          <p className="mb-2 font-mono text-[11px] uppercase tracking-[0.08em] text-text-faint">
+            Project {String(index + 1).padStart(2, "0")}
+          </p>
+          <h3 className="mb-1 text-h2 font-semibold">{project.title}</h3>
+          <p className="mb-4 text-sm text-text-muted">
+            {project.tagline} — {project.description}
+          </p>
+          <motion.div variants={tagContainerVariants} className="flex flex-wrap gap-2">
+            {project.tags.map((tag) => (
+              <motion.span
+                key={tag}
+                variants={tagVariants}
+                className="rounded-sm bg-accent-blue/10 px-3 py-1 font-mono text-xs text-accent-blue"
+              >
+                {tag}
+              </motion.span>
+            ))}
+          </motion.div>
+        </div>
+      </Link>
+    </motion.div>
+  );
+}

--- a/src/components/projects/ProjectCaseStudy.tsx
+++ b/src/components/projects/ProjectCaseStudy.tsx
@@ -1,0 +1,98 @@
+import Image from "next/image";
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import type { Project } from "@/data/projects";
+
+export function ProjectCaseStudy({ project }: { project: Project }) {
+  return (
+    <article className="px-(--space-container-x) py-(--space-section-y)">
+      <div className="mx-auto max-w-4xl">
+        <ScrollReveal delay={0}>
+          <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">
+            {project.tagline}
+          </p>
+          <h1 className="mb-6 text-h1 font-semibold">{project.title}</h1>
+        </ScrollReveal>
+
+        <ScrollReveal delay={0.1}>
+          <div className="relative mb-8 aspect-video overflow-hidden rounded-lg">
+            <Image
+              src={project.coverImage}
+              alt={`${project.title} cover`}
+              fill
+              sizes="(min-width: 1024px) 896px, 100vw"
+              className="object-cover"
+              priority
+            />
+          </div>
+        </ScrollReveal>
+
+        <ScrollReveal delay={0.2}>
+          <p className="mb-6 leading-relaxed text-text-muted">{project.description}</p>
+          <div className="mb-8 flex flex-wrap gap-2">
+            {project.tags.map((tag) => (
+              <span key={tag} className="rounded-sm border border-border px-3 py-1 font-mono text-xs">
+                {tag}
+              </span>
+            ))}
+          </div>
+          <div className="mb-12 flex gap-4">
+            <a
+              href={project.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-sm bg-text px-5 py-2.5 text-sm font-medium text-bg"
+            >
+              Live Site
+            </a>
+            <a
+              href={project.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-sm border border-border px-5 py-2.5 text-sm font-medium"
+            >
+              Source
+            </a>
+          </div>
+        </ScrollReveal>
+
+        {project.caseStudy && (
+          <div className="space-y-10">
+            <ScrollReveal delay={0}>
+              <h2 className="mb-2 text-h2 font-semibold">Problem</h2>
+              <p className="leading-relaxed text-text-muted">{project.caseStudy.problem}</p>
+            </ScrollReveal>
+            <ScrollReveal delay={0.1}>
+              <h2 className="mb-2 text-h2 font-semibold">Architecture</h2>
+              <p className="leading-relaxed text-text-muted">{project.caseStudy.architecture}</p>
+            </ScrollReveal>
+            <ScrollReveal delay={0.1}>
+              <h2 className="mb-2 text-h2 font-semibold">Features</h2>
+              <ul className="list-inside list-disc space-y-1 text-text-muted">
+                {project.caseStudy.features.map((feature) => (
+                  <li key={feature}>{feature}</li>
+                ))}
+              </ul>
+            </ScrollReveal>
+            <ScrollReveal delay={0.1}>
+              <h2 className="mb-2 text-h2 font-semibold">Stack</h2>
+              <div className="flex flex-wrap gap-2">
+                {project.caseStudy.stack.map((tech) => (
+                  <span
+                    key={tech}
+                    className="rounded-sm bg-accent-blue/10 px-3 py-1 font-mono text-xs text-accent-blue"
+                  >
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            </ScrollReveal>
+            <ScrollReveal delay={0.1}>
+              <h2 className="mb-2 text-h2 font-semibold">Result</h2>
+              <p className="leading-relaxed text-text-muted">{project.caseStudy.result}</p>
+            </ScrollReveal>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/src/components/projects/ProjectPreview.tsx
+++ b/src/components/projects/ProjectPreview.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { motion, type Variants } from "motion/react";
+import Image from "next/image";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { DURATION_FAST, EASE_OUT_EXPO } from "@/lib/motion";
+import type { Project } from "@/data/projects";
+
+const overlayVariants: Variants = {
+  rest: { opacity: 0 },
+  hover: { opacity: 1, transition: { duration: DURATION_FAST } },
+};
+
+const labelVariants: Variants = {
+  rest: { y: 12, opacity: 0 },
+  hover: { y: 0, opacity: 1, transition: { duration: DURATION_FAST, ease: EASE_OUT_EXPO } },
+};
+
+export function ProjectPreview({ project }: { project: Project }) {
+  const canHover = useMediaQuery("(hover: hover) and (pointer: fine)");
+
+  return (
+    <motion.div
+      className="relative aspect-video overflow-hidden rounded-lg bg-bg-elevated"
+      initial="rest"
+      animate="rest"
+      whileHover={canHover ? "hover" : undefined}
+    >
+      <Image
+        src={project.coverImage}
+        alt={`${project.title} preview`}
+        fill
+        sizes="(min-width: 1024px) 480px, 100vw"
+        className="object-cover"
+      />
+      <motion.div
+        variants={overlayVariants}
+        className="absolute inset-0 flex items-center justify-center bg-bg/70"
+      >
+        <motion.span
+          variants={labelVariants}
+          className="font-mono text-xs uppercase tracking-[0.08em] text-text"
+        >
+          View case study →
+        </motion.span>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,7 +1,41 @@
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+
+const SKILLS = ["React", "Next.js", "TypeScript", "Node.js"];
+
 export function About() {
   return (
-    <section id="about" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">About</h2>
+    <section id="about" className="relative px-(--space-container-x) py-(--space-section-y)">
+      <div className="mx-auto grid max-w-5xl items-center gap-12 md:grid-cols-2">
+        <ScrollReveal delay={0}>
+          <div className="flex aspect-4/5 items-center justify-center rounded-lg border border-border bg-bg-elevated">
+            <span className="text-sm text-text-faint">[ portrait placeholder ]</span>
+          </div>
+        </ScrollReveal>
+        <div>
+          <ScrollReveal delay={0.1}>
+            <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">About</p>
+            <h2 className="mb-4 text-h1 font-semibold">Pravin K</h2>
+          </ScrollReveal>
+          <ScrollReveal delay={0.2}>
+            <p className="mb-2 text-text-muted">Full Stack Developer</p>
+            <p className="mb-6 leading-relaxed text-text-muted">
+              Placeholder bio — replace with real copy. I build end-to-end web applications with a
+              focus on clean architecture, performance, and interfaces that feel considered rather
+              than decorated.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {SKILLS.map((skill) => (
+                <span
+                  key={skill}
+                  className="rounded-sm border border-border px-3 py-1 font-mono text-xs"
+                >
+                  {skill}
+                </span>
+              ))}
+            </div>
+          </ScrollReveal>
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,7 +1,39 @@
+"use client";
+
+import { AnimatedText } from "@/components/ui/AnimatedText";
+import { GlowBackground } from "@/components/ui/GlowBackground";
+import { MagneticButton } from "@/components/ui/MagneticButton";
+import { useCursor } from "@/context/CursorContext";
+
 export function Contact() {
+  const { setCursor } = useCursor();
+
   return (
-    <section id="contact" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">Contact</h2>
+    <section
+      id="contact"
+      className="relative overflow-hidden px-(--space-container-x) py-[clamp(6rem,14vw,10rem)]"
+    >
+      <GlowBackground />
+      <div className="relative mx-auto max-w-3xl text-center">
+        <p className="mb-6 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">
+          Have an idea?
+        </p>
+        <h2 className="text-[clamp(2.5rem,7vw,5rem)] font-semibold leading-[1.02] tracking-tight">
+          <AnimatedText text="LET'S" mode="chars" trigger="inView" className="block" />
+          <AnimatedText text="BUILD" mode="chars" trigger="inView" delay={0.2} className="block" />
+          <AnimatedText text="IT." mode="chars" trigger="inView" delay={0.4} className="block" />
+        </h2>
+        <MagneticButton className="mt-10">
+          <a
+            href="mailto:pravinkumar671231@gmail.com"
+            onMouseEnter={() => setCursor("talk")}
+            onMouseLeave={() => setCursor("default")}
+            className="inline-flex items-center rounded-sm bg-text px-8 py-4 text-sm font-medium text-bg transition-opacity hover:opacity-90"
+          >
+            Let&apos;s Talk
+          </a>
+        </MagneticButton>
+      </div>
     </section>
   );
 }

--- a/src/components/sections/Github.tsx
+++ b/src/components/sections/Github.tsx
@@ -1,7 +1,119 @@
-export function Github() {
+"use client";
+
+import { animate, motion, useInView, useMotionValue, type Variants } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+import { useCursor } from "@/context/CursorContext";
+import { fetchGithubStats } from "@/lib/github";
+
+const GITHUB_USER = "Pravin671231";
+
+/**
+ * Deterministic seeded PRNG (mulberry32) — never Math.random() here, since
+ * this grid must render identically on the server and the client to avoid
+ * a hydration mismatch. Fixed seed, computed once at module scope.
+ */
+function seededGrid(seed: number, count: number): number[] {
+  let t = seed;
+  const cells: number[] = [];
+  for (let i = 0; i < count; i++) {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    cells.push(((r ^ (r >>> 14)) >>> 0) / 4294967296);
+  }
+  return cells;
+}
+
+const GRID_CELLS = seededGrid(42, 140);
+
+const gridContainerVariants: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.008 } },
+};
+
+const cellVariants: Variants = {
+  hidden: { opacity: 0, scale: 0.6 },
+  visible: { opacity: 1, scale: 1, transition: { duration: 0.2 } },
+};
+
+function CountUp({ value, label }: { value: number; label: string }) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const inView = useInView(ref, { once: true, amount: 0.5 });
+  const motionValue = useMotionValue(0);
+  const [display, setDisplay] = useState("00");
+
+  useEffect(() => {
+    if (!inView) return;
+    const controls = animate(motionValue, value, {
+      duration: 1.2,
+      ease: "easeOut",
+      onUpdate: (v) => setDisplay(String(Math.round(v)).padStart(2, "0")),
+    });
+    return () => controls.stop();
+  }, [inView, value, motionValue]);
+
   return (
-    <section id="github" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">GitHub</h2>
+    <div>
+      <p ref={ref} className="font-mono text-4xl font-semibold">
+        {display}
+      </p>
+      <p className="mt-2 text-sm text-text-muted">{label}</p>
+    </div>
+  );
+}
+
+export function Github() {
+  const [stats, setStats] = useState({ repos: 0, followers: 0, totalStars: 0 });
+  const { setCursor } = useCursor();
+
+  useEffect(() => {
+    fetchGithubStats().then(setStats);
+  }, []);
+
+  return (
+    <section id="github" className="relative px-(--space-container-x) py-(--space-section-y)">
+      <div className="mx-auto max-w-4xl text-center">
+        <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">GitHub</p>
+        <h2 className="mb-12 text-h1 font-semibold">
+          <a
+            href={`https://github.com/${GITHUB_USER}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onMouseEnter={() => setCursor("code")}
+            onMouseLeave={() => setCursor("default")}
+          >
+            Open Source Activity
+          </a>
+        </h2>
+
+        <div className="mb-12 grid grid-cols-3 gap-6">
+          <CountUp value={stats.repos} label="Repositories" />
+          <CountUp value={stats.followers} label="Followers" />
+          <CountUp value={stats.totalStars} label="Stars" />
+        </div>
+
+        <motion.div
+          className="mx-auto grid max-w-xl gap-1"
+          style={{ gridTemplateColumns: "repeat(20, minmax(0,1fr))" }}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={gridContainerVariants}
+        >
+          {GRID_CELLS.map((intensity, i) => (
+            <motion.div
+              key={i}
+              variants={cellVariants}
+              className="aspect-square rounded-sm bg-accent-blue"
+              style={{ opacity: 0.1 + intensity * 0.6 }}
+            />
+          ))}
+        </motion.div>
+        <p className="mt-4 font-mono text-xs text-text-faint">
+          Mock activity grid — real contribution data requires the authenticated GitHub GraphQL API
+          (Phase 2).
+        </p>
+      </div>
     </section>
   );
 }

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,7 +1,65 @@
+"use client";
+
+import { motion } from "motion/react";
+import { ChevronDown } from "lucide-react";
+import { AnimatedText } from "@/components/ui/AnimatedText";
+import { GlowBackground } from "@/components/ui/GlowBackground";
+import { MagneticButton } from "@/components/ui/MagneticButton";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { DURATION_BASE, EASE_IN_OUT } from "@/lib/motion";
+
 export function Hero() {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
-    <section className="flex min-h-screen items-center justify-center">
-      <h1 className="text-4xl font-semibold">Hero</h1>
+    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-(--space-container-x)">
+      <GlowBackground />
+
+      <div className="relative max-w-3xl text-center">
+        <p className="mb-6 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">
+          Available for work
+        </p>
+        <h1 className="text-display font-semibold tracking-tight">
+          <AnimatedText text="Hi, I'm Pravin." mode="words" trigger="mount" />
+        </h1>
+        <motion.p
+          className="mx-auto mt-6 max-w-xl text-lg text-text-muted md:text-xl"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: DURATION_BASE, delay: prefersReducedMotion ? 0.1 : 0.7 }}
+        >
+          Full Stack Developer building fast, thoughtful products with Next.js, TypeScript &amp; Node.js.
+        </motion.p>
+        <div className="mt-10 flex items-center justify-center gap-4">
+          <MagneticButton>
+            <a
+              href="#projects"
+              className="rounded-sm bg-text px-6 py-3 text-sm font-medium text-bg transition-opacity hover:opacity-90"
+            >
+              View My Work
+            </a>
+          </MagneticButton>
+          <a
+            href="#contact"
+            className="rounded-sm border border-border px-6 py-3 text-sm font-medium transition-colors hover:border-accent-blue hover:text-accent-blue"
+          >
+            Let&apos;s Talk
+          </a>
+        </div>
+      </div>
+
+      <motion.div
+        className="absolute bottom-10 flex flex-col items-center text-text-faint"
+        animate={prefersReducedMotion ? undefined : { y: [0, 8, 0] }}
+        transition={
+          prefersReducedMotion
+            ? undefined
+            : { duration: 1.6, repeat: Infinity, ease: EASE_IN_OUT }
+        }
+      >
+        <span className="mb-2 font-mono text-[10px] uppercase tracking-[0.08em]">Scroll</span>
+        <ChevronDown size={16} aria-hidden />
+      </motion.div>
     </section>
   );
 }

--- a/src/components/sections/Process.tsx
+++ b/src/components/sections/Process.tsx
@@ -1,7 +1,81 @@
+"use client";
+
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useLayoutEffect, useRef } from "react";
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(ScrollTrigger);
+}
+
+const STEPS = [
+  { n: "01", title: "Understand", body: "Clarify the problem before touching code." },
+  { n: "02", title: "Design", body: "Sketch architecture and data flow." },
+  { n: "03", title: "Build", body: "Ship in small, testable increments." },
+  { n: "04", title: "Test", body: "Verify against real usage, not assumptions." },
+  { n: "05", title: "Deploy", body: "Ship with monitoring in place." },
+  { n: "06", title: "Improve", body: "Iterate based on real feedback." },
+];
+
 export function Process() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const lineRef = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  useLayoutEffect(() => {
+    if (!lineRef.current) return;
+
+    if (prefersReducedMotion) {
+      // Static, fully filled — no ScrollTrigger instance created at all.
+      gsap.set(lineRef.current, { scaleY: 1 });
+      return;
+    }
+
+    const ctx = gsap.context(() => {
+      gsap.set(lineRef.current, { scaleY: 0, transformOrigin: "top center" });
+      gsap.to(lineRef.current, {
+        scaleY: 1,
+        ease: "none",
+        scrollTrigger: {
+          trigger: sectionRef.current,
+          start: "top 70%",
+          end: "bottom 70%",
+          scrub: true,
+        },
+      });
+    }, sectionRef);
+
+    return () => ctx.revert();
+  }, [prefersReducedMotion]);
+
   return (
-    <section id="process" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">How I Build</h2>
+    <section
+      id="process"
+      ref={sectionRef}
+      className="relative px-(--space-container-x) py-(--space-section-y)"
+    >
+      <div className="mx-auto max-w-3xl">
+        <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">
+          How I Build
+        </p>
+        <h2 className="mb-12 text-h1 font-semibold">Process</h2>
+
+        <ol className="relative space-y-10 pl-8">
+          <div ref={lineRef} className="absolute bottom-0 left-0 top-0 w-px bg-accent-blue" />
+          {STEPS.map((step) => (
+            <ScrollReveal key={step.n} delay={0} y={16}>
+              <li className="relative">
+                <span className="absolute -left-7.25 top-1 h-2.5 w-2.5 rounded-full bg-accent-blue" />
+                <p className="mb-1 font-mono text-xs text-text-faint">{step.n}</p>
+                <h3 className="mb-1 font-semibold">{step.title}</h3>
+                <p className="text-sm text-text-muted">{step.body}</p>
+              </li>
+            </ScrollReveal>
+          ))}
+        </ol>
+      </div>
     </section>
   );
 }

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,7 +1,85 @@
+"use client";
+
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { useLayoutEffect, useRef } from "react";
+import { ProjectCard } from "@/components/projects/ProjectCard";
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { projects } from "@/data/projects";
+
+if (typeof window !== "undefined") {
+  gsap.registerPlugin(ScrollTrigger);
+}
+
 export function Projects() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const isTouch = useMediaQuery("(pointer: coarse)");
+  const prefersReducedMotion = useReducedMotion();
+  const pinnedMode = isDesktop && !isTouch && !prefersReducedMotion;
+
+  useLayoutEffect(() => {
+    if (!pinnedMode) return; // zero ScrollTrigger instances created in the fallback branch
+
+    const ctx = gsap.context(() => {
+      const track = trackRef.current;
+      if (!track) return;
+
+      const distance = () => Math.max(0, track.scrollWidth - window.innerWidth);
+
+      gsap.to(track, {
+        x: () => -distance(),
+        ease: "none",
+        scrollTrigger: {
+          trigger: sectionRef.current,
+          start: "top top",
+          end: () => `+=${distance()}`,
+          scrub: 1,
+          pin: true,
+          invalidateOnRefresh: true,
+        },
+      });
+    }, sectionRef);
+
+    return () => ctx.revert();
+  }, [pinnedMode]);
+
   return (
-    <section id="projects" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">Projects</h2>
+    <section
+      id="projects"
+      ref={sectionRef}
+      className="relative px-(--space-container-x) py-(--space-section-y)"
+    >
+      <div className="mx-auto max-w-6xl">
+        <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">
+          Selected Work
+        </p>
+        <h2 className="mb-12 text-h1 font-semibold">Projects</h2>
+      </div>
+
+      {pinnedMode ? (
+        <div className="h-screen overflow-hidden">
+          <div ref={trackRef} className="flex w-max gap-8 will-change-transform">
+            {projects.map((project, i) => (
+              <div key={project.slug} className="w-[85vw] max-w-xl shrink-0">
+                <ProjectCard project={project} index={i} />
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="mx-auto grid max-w-6xl gap-8">
+          {projects.map((project, i) => (
+            <ScrollReveal key={project.slug} delay={Math.min(i * 0.1, 0.3)}>
+              <ProjectCard project={project} index={i} />
+            </ScrollReveal>
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,13 @@
+import type { GithubStats } from "@/app/api/github/route";
+
+const FALLBACK: GithubStats = { repos: 0, followers: 0, totalStars: 0, error: true };
+
+export async function fetchGithubStats(): Promise<GithubStats> {
+  try {
+    const res = await fetch("/api/github");
+    if (!res.ok) throw new Error("Failed to load GitHub stats");
+    return await res.json();
+  } catch {
+    return FALLBACK;
+  }
+}


### PR DESCRIPTION
## Summary
Turns the M0 heading-only stubs into the real, animated MVP experience — all 10 M1 issues (#14–#23):

- **Hero** — AnimatedText mount-triggered headline, GlowBackground, scroll indicator, magnetic CTA
- **About** — staggered ScrollReveal sections
- **ProjectPreview/ProjectCard** — hover overlay + tag stagger, gated on `(hover: hover) and (pointer: fine)`, wired to `view` cursor mode
- **Projects** — GSAP ScrollTrigger pinned horizontal scroll at ≥1024px + motion-enabled, with a genuinely separate vertical-stack fallback (zero ScrollTrigger instances) below that/touch/reduced-motion
- **Project case-study route** (`/projects/[slug]`) — case-study breakdown only renders when present (TechCart only)
- **Process** — GSAP-scrubbed vertical line fill, same `gsap.context`/`ctx.revert` idiom as Projects
- **`/api/github` route + `lib/github.ts`** — live stats for Pravin671231, verified against the real API before building UI on it
- **Github section** — count-up via Motion, mock contribution grid with a deterministic seeded PRNG (no hydration mismatch)
- **Contact** — char-stagger headline, magnetic CTA wired to `talk` cursor mode
- 4 placeholder cover SVGs

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean, no warnings
- [x] Tailwind-CSS-compiled check — clean
- [x] `npx tsc --noEmit` — clean
- [x] `/api/github` verified against real live data before Github section UI was built
- [x] All 4 case-study routes checked (3 without a caseStudy breakdown, 1 with); unknown slug → 404
- [x] Dev server runtime log clean, no GSAP/console errors across multiple reloads
- [ ] CI run on this PR (will confirm once it completes)

Per the CLAUDE.md convention: no `Closes #N` here — issues #14–#23 get closed explicitly after the merge and the Project Status update, not automatically by this PR.