### PR TITLE
Add local Claude skills for repo workflows

### DIFF
--- a/.claude/skills/auto-commit-push/SKILL.md
+++ b/.claude/skills/auto-commit-push/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: auto-commit-push
+description: Single-pass, no-gate workflow that stages, commits, and pushes changes already present in the working tree, then reports status. Auto Mode only — no confirmation gates. Use when the user says "/auto-commit-push", or asks to commit and push without stopping to confirm each step.
+---
+
+# Auto Commit & Push
+
+Mode: **Auto Mode** — run all three steps back-to-back with no confirmation gate between them. Don't ask "should I commit?" or "should I push?" mid-flow. Only stop if a step fails outright (nothing to commit, push rejected, hook failure) or the situation is genuinely ambiguous (e.g. detached HEAD, no upstream and no clear target remote).
+
+This skill assumes changes already exist in the working tree — it does not implement anything itself.
+
+## Step 1 — Commit the required changes
+
+- Run `git status`, `git diff` (staged + unstaged), and `git log --oneline -5` to see what changed and match this repo's commit style.
+- If there's nothing to commit, stop and tell the user — do not proceed to Step 2/3.
+- Stage the relevant files by name (avoid `git add -A`/`.` if it would sweep in unrelated or sensitive files — check `git status` first).
+- Write a concise commit message describing why the change was made, following the repo's existing convention if one is evident from recent history.
+- Commit. Standard git safety rules apply: never `--force`, never skip hooks (`--no-verify`), never amend an existing commit — always a new commit. If a pre-commit hook fails, fix the issue, re-stage, and commit again as a new commit.
+
+## Step 2 — Push to the current branch
+
+- Determine the current branch: `git branch --show-current`.
+- Push: `git push`, or `git push -u origin <branch>` if it has no upstream yet.
+- Never force-push. If the push is rejected (e.g. remote has diverged), stop and report — do not force or rebase over the user's history without asking first.
+
+## Step 3 — Confirm
+
+- Run `git status` and `git log -1 --oneline` to confirm the push landed and local/remote are in sync.
+- Report: commit SHA + message, branch name, and confirmation that the push succeeded.
+
+"Auto Mode" here means behavioral continuity — proceeding through all three steps without pausing for approval — not a literal mode-switch tool call.

--- a/.claude/skills/auto-pr-merge/SKILL.md
+++ b/.claude/skills/auto-pr-merge/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: auto-pr-merge
+description: Single-pass, no-gate workflow that opens a PR from the current branch, waits for CI to pass, squash-merges into main, deletes the branch, syncs local main to the latest, and — if the repo documents its own post-merge status-doc convention — syncs those docs via a follow-up PR too. Auto Mode only — no confirmation gates. Use when the user says "/auto-pr-merge", or asks to create a PR and merge it, merge to main and clean up, or ship the current branch.
+---
+
+# Auto PR & Merge
+
+Mode: **Auto Mode** — run all steps back-to-back with no confirmation gate between them. Don't ask "should I open the PR?" or "should I merge?" mid-flow. Only stop if a step fails outright (nothing to PR, CI fails, merge rejected, local sync blocked) or the situation is genuinely ambiguous (e.g. already on `main`, detached HEAD, uncommitted changes present).
+
+Every action this skill takes — pushing, opening the PR, merging, deleting the branch, checking out and pulling the base branch, and (when Step 6 applies) the follow-up doc-sync PR — is pre-approved simply by the user invoking this skill. Treat any point that would normally prompt "confirm?" as already answered yes; do not pause mid-flow to ask again for any of these specific actions.
+
+This skill assumes the current branch's work is already committed and pushed (or push-able) — it does not implement or commit anything itself. If there's uncommitted work, stop and tell the user (chaining after a commit/push skill first is their call, not this skill's).
+
+## Step 1 — Pre-flight
+
+- `git status` — if there are uncommitted changes, stop and report; do not proceed.
+- `git branch --show-current` — if this is `main`/`master` or detached HEAD, stop: nothing to PR.
+- `git log origin/<base>..HEAD --oneline` (base is `main` unless the repo's docs say otherwise) — if empty, stop: nothing ahead of base to merge.
+- Push the branch if it isn't already up to date with its remote (`git push`, or `git push -u origin <branch>` with no upstream yet) — same push safety rules as `auto-commit-push`: never force.
+
+## Step 2 — Open the PR (or reuse an existing one)
+
+- Check for an existing PR first: `gh pr list --head <branch> --state open`. Reuse it if found — don't open a duplicate.
+- Otherwise create one: `gh pr create --base <base> --head <branch> --title ... --body ...`. Derive the title/summary from the branch's own commit history (`git log <base>..HEAD`); reference an issue with `Closes #N` if the branch name or commits name one. Match the repo's own PR-body conventions if a template or prior-PR pattern is evident.
+
+## Step 3 — Wait for CI and ensure it passes
+
+- `gh pr checks <number> --watch` until every check reaches a final state.
+- If any required check fails, **stop** — report which check failed and its link. Do not merge a red PR under any circumstances, regardless of Auto Mode.
+
+## Step 4 — Merge
+
+- Merge using the repo's documented convention if discoverable (e.g. a `CLAUDE.md`/`AGENTS.md`/`CONTRIBUTING.md` stating squash-merge only, linear history) — default to `gh pr merge <number> --squash --delete-branch` when no convention is documented.
+- Never force-merge past a failing/blocking check. If the merge is rejected (branch protection, conflicts with base since the PR opened), stop and report — do not bypass with admin overrides.
+
+## Step 5 — Delete the branch and sync local base branch
+
+- Confirm the remote branch is gone (`--delete-branch` already requested this; verify via `git fetch --prune` + `git branch -a`).
+- `git status` again before switching (standing safety rule — never discard uncommitted work silently).
+- `git checkout <base>` (e.g. `main`), then `git pull` to fast-forward to the just-merged commit.
+- Delete the local feature branch with `git branch -d <branch>` (lowercase `-d`, not `-D` — refuses if not actually merged, a safety net that should never trigger here since it just was).
+
+## Step 6 — Root docs sync (only if the repo's own process calls for it)
+
+- Check whether the repo documents a post-merge status-sync convention of its own (e.g. a root `CLAUDE.md` that says something like "once merged, sync the status sections of `AGENTS.md`/`CLAUDE.md`/`docs/architecture.md` in a small follow-up PR"). If no such convention is documented anywhere in the repo, skip this step entirely — most repos won't have one.
+- If it is documented: update those root status sections to reflect the just-merged change, following the existing style/wording pattern from prior status-sync commits (`git log --oneline --grep=sync`, or similar, to find precedent). Then repeat Steps 1–5 for this doc-only change on its own small branch — commit, push, open a PR, wait for CI, merge, delete the branch, sync local `<base>` again — same Auto Mode continuity, no gate. Never push doc-only changes directly to a protected base branch if the repo rejects direct pushes.
+
+## Step 7 — Confirm
+
+- Report: PR number + URL, merge commit SHA, confirmation CI passed (which checks), confirmation the branch is deleted both remotely and locally, confirmation local `<base>` is now up to date with `origin/<base>`, and — if Step 6 ran — the same for the follow-up doc-sync PR.
+
+"Auto Mode" here means behavioral continuity — proceeding through all steps without pausing for approval — not a literal mode-switch tool call.

--- a/.claude/skills/discuss-plan-build/SKILL.md
+++ b/.claude/skills/discuss-plan-build/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: discuss-plan-build
+description: Implementation workflow — discuss requirements, confirm them, enter Plan Mode and write a step-by-step plan (implementation + testing + verification), confirm the plan, list the tasks and confirm Auto Mode (continuous) or Manual Mode (pause per task) before executing, tracking a live task checklist throughout, ending in a short summary. Use when the user says "/discuss-plan-build", or asks to discuss and confirm requirements before planning, or to plan and confirm before implementing.
+---
+
+# Discuss → Plan → Build
+
+A generic, project-agnostic workflow for any implementation task. It runs through three confirmation gates — requirements, plan, and execution mode — before execution begins, and never skips one.
+
+## Rule
+
+- **Plan Mode:** after the plan is confirmed, list the implementation steps in detail.
+- **Auto Mode:** execute the confirmed step-by-step plan continuously, with no per-task stops.
+- **Manual Mode:** execute the confirmed plan one task at a time, pausing after each for explicit user go-ahead before starting the next.
+- Which of the two runs is confirmed with the user right after the plan is approved (Step 4.5) — never assumed.
+
+## Step 1 — Ask / Discuss
+
+Discuss the feature or task with the user before touching anything:
+- Clarify scope, expected behavior, constraints, edge cases, and dependencies.
+- Read code only as needed to ask informed questions — don't do a full codebase survey yet, that belongs in Step 3.
+- Do **not** start implementation, and do not write a plan file yet.
+
+## Step 2 — Requirement Confirmation
+
+- Summarize the agreed requirements back to the user as a short, concrete list.
+- Ask for explicit confirmation.
+- Do not proceed to Plan Mode until confirmed. If the user's answer is "yes, but also X," fold X in and summarize again — a partial or ambiguous yes is not confirmation.
+
+## Step 3 — Plan Mode
+
+Once requirements are confirmed:
+1. Enter Plan Mode (call `EnterPlanMode`).
+2. Review the relevant project files and project instructions — the repo's own `CLAUDE.md`/`AGENTS.md` if present, and existing patterns in the codebase. For anything non-trivial or with uncertain scope, use the Explore agent to survey rather than guessing.
+3. Write a complete, step-by-step implementation plan to the plan file, with implementation, testing, and verification covered explicitly (as their own sections or clearly distinguishable within the steps) — not just "write the code."
+
+If the project itself has its own spec/issue/branch process (an SRS, an issue tracker workflow, a documented branching convention), fold that into the plan rather than skipping it — this skill doesn't override a project's own process, it wraps around it.
+
+## Step 4 — Plan Confirmation
+
+- Call `ExitPlanMode` to present the plan.
+- Wait for explicit approval.
+- If the user requests changes, revise the plan and call `ExitPlanMode` again. Never implement before approval — a rejection means revise-and-re-present, not proceeding anyway.
+
+## Step 4.5 — Task List & Execution Mode Confirmation
+
+Once the plan is approved (Step 4):
+1. List the implementation tasks as an ordered checklist, all `⬜ Pending`, each with a specific, descriptive name naming its concrete deliverable (not a generic phase label) — the same format the Task Progress Rule below defines; this step produces its first rendering.
+2. Ask the user (via `AskUserQuestion`) which mode to execute in:
+   - **Auto Mode** — execute every task directly and continuously, no per-task stops (Step 5's default behavior).
+   - **Manual Mode** — execute one task, mark it Completed, then stop and wait for the user's explicit go-ahead before starting the next task. The checklist is still shown/updated the same way; only the pacing differs.
+3. Do not begin execution until a mode is chosen. This is a one-time choice for the whole task list, not asked again per task.
+4. **If the mode-choice question is rejected/declined/left unanswered**, that counts as the mode being resolved, not skipped: default to **Auto Mode** and continue immediately — do not stay blocked waiting for a re-ask, and do not treat the rejection as a request to stop the whole workflow. A rejection here means "skip choosing, just proceed," not "cancel."
+
+## Task Progress Rule
+
+After the plan is approved, display the implementation tasks as an ordered checklist and update their status continuously as execution progresses. Each task's name must be specific and descriptive — naming the concrete deliverable or action (e.g., a function, file, or behavior) — not a generic phase label like "Implementation"/"Testing"/"Verification" on its own.
+
+Example:
+
+```
+☑️ Create toTitleCase function — Completed
+🔄 Add assertion checks — In Progress
+⬜ Run and verify output — Pending
+⬜ Update docs — Pending
+```
+
+When "Add assertion checks" is completed:
+
+```
+☑️ Create toTitleCase function — Completed
+☑️ Add assertion checks — Completed
+🔄 Run and verify output — In Progress
+⬜ Update docs — Pending
+```
+
+Continue this process until all tasks are completed.
+
+Rules:
+- Tasks must always be executed in the defined order.
+- A task must be marked Completed only after it has actually been finished and verified.
+- When moving to the next task, mark it In Progress.
+- Completed tasks must remain marked as completed unless actual rework is required.
+- In Auto Mode, do not ask for user approval between individual tasks — continue continuously through the entire list. In Manual Mode (chosen in Step 4.5), pause after each task's completion and wait for the user's go-ahead before starting the next; this is the one deliberate exception to that rule. Auto Mode is also the fallback default whenever Step 4.5's mode question goes unanswered/rejected — see Step 4.5, point 4.
+- After all tasks are completed, provide the final Completion summary (Step 6) — changes made, tests/verification performed, and any remaining items.
+
+## Step 5 — Execution
+
+This is the **Auto Mode** path (chosen in Step 4.5): implement the confirmed plan continuously, in one pass:
+- Work through every task without pausing to re-confirm each individual one — that back-and-forth is what Steps 2, 4, and 4.5 already cleared.
+- Display and update the task checklist continuously per the Task Progress Rule above.
+- Run the planned tests/verification as part of this same pass, not as a separate follow-up the user has to ask for.
+- Pause only for something the plan couldn't have anticipated: an unexpected destructive/irreversible action not already covered by the plan, a genuinely blocking ambiguity, or information only the user can supply.
+
+"Auto Mode" here means behavioral continuity — working straight through without stopping to ask permission at each step — not a literal mode-switch tool call. Actual tool permissions are still governed by whatever permission mode the session is running under; this skill doesn't and can't override that.
+
+If **Manual Mode** was chosen instead: execute one task, update the checklist, then stop and explicitly ask the user to proceed before starting the next task. Everything else above (checklist display, running that task's own tests/verification, pausing for genuine blockers) still applies per task.
+
+## Step 6 — Completion
+
+Give a short final summary covering:
+- What was changed.
+- What was tested/verified.
+- Any remaining work or known issues.
+
+## Final Flow
+
+`Ask/Discuss → Requirement Confirmation → Plan Mode → Create Plan → Plan Confirmation → Task List & Mode Confirmation → Auto/Manual Execute → Test/Verify → Done`


### PR DESCRIPTION
## Summary
Vendors three workflow skills into `.claude/skills/` so they travel with the repo instead of living only in the user's global Claude config:

- **discuss-plan-build** — discuss → confirm requirements → Plan Mode → confirm plan → task list + Auto/Manual mode → execute → summary
- **auto-pr-merge** — open PR, wait for CI, squash-merge, delete branch, sync local main, and (per this repo's CLAUDE.md convention) follow-up doc-sync PR
- **auto-commit-push** — stage, commit, push, report; no confirmation gates

Content is copied verbatim from the existing global versions.

## Test plan
- [x] `git status` clean; only `.claude/skills/**` added
- [ ] CI run on this PR

Per the CLAUDE.md convention: no `Closes #N`.