### PR TITLE
Implement M2 stub sections: Stack, Journey, Certifications, Testimonials

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,6 +85,7 @@ html[data-theme="light"] {
   --duration-fast: 0.2s;
   --duration-base: 0.4s;
   --duration-slow: 0.8s;
+  --duration-float: 8s;
 
   --z-nav: 40;
   --z-command-palette: 50;
@@ -113,4 +114,26 @@ body {
 .cursor-none-desktop,
 .cursor-none-desktop * {
   cursor: none;
+}
+
+/* FloatingCode decorative glyphs — plain CSS loop, no JS animation library.
+   Reduced-motion users get the glyphs statically in place, not removed. */
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-16px);
+  }
+}
+
+.animate-float {
+  animation: float var(--duration-float) ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-float {
+    animation: none;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider, THEME_INIT_SCRIPT } from "@/context/ThemeContext";
 import { CursorProvider } from "@/context/CursorContext";
 import { SmoothScrollProvider } from "@/components/layout/SmoothScrollProvider";
 import { CustomCursor } from "@/components/ui/CustomCursor";
+import { CommandPalette } from "@/components/ui/CommandPalette";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
 
@@ -41,6 +42,7 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
           <CursorProvider>
             <SmoothScrollProvider>
               <CustomCursor />
+              <CommandPalette />
               <Navbar />
               {children}
               <Footer />

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,3 +1,4 @@
+import { FloatingCode } from "@/components/ui/FloatingCode";
 import { ScrollReveal } from "@/components/ui/ScrollReveal";
 
 const SKILLS = ["React", "Next.js", "TypeScript", "Node.js"];
@@ -5,6 +6,7 @@ const SKILLS = ["React", "Next.js", "TypeScript", "Node.js"];
 export function About() {
   return (
     <section id="about" className="relative px-(--space-container-x) py-(--space-section-y)">
+      <FloatingCode />
       <div className="mx-auto grid max-w-5xl items-center gap-12 md:grid-cols-2">
         <ScrollReveal delay={0}>
           <div className="flex aspect-4/5 items-center justify-center rounded-lg border border-border bg-bg-elevated">

--- a/src/components/sections/Certifications.tsx
+++ b/src/components/sections/Certifications.tsx
@@ -1,7 +1,43 @@
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import { certifications } from "@/data/certifications";
+
 export function Certifications() {
   return (
-    <section id="certifications" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">Certifications</h2>
+    <section id="certifications" className="px-(--space-container-x) py-(--space-section-y)">
+      <div className="mx-auto max-w-5xl">
+        <ScrollReveal>
+          <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">
+            Certifications
+          </p>
+          <h2 className="mb-10 text-h1 font-semibold">Credentials</h2>
+        </ScrollReveal>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {certifications.map((cert, index) => (
+            <ScrollReveal key={cert.id} delay={index * 0.1}>
+              <div className="rounded-lg border border-border bg-bg-elevated p-6">
+                <h3 className="mb-1 text-h2 font-semibold">
+                  {cert.url ? (
+                    <a
+                      href={cert.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="transition-colors hover:text-accent-blue"
+                    >
+                      {cert.title}
+                    </a>
+                  ) : (
+                    cert.title
+                  )}
+                </h3>
+                <p className="mb-2 text-sm text-text-muted">{cert.issuer}</p>
+                <p className="font-mono text-xs uppercase tracking-[0.08em] text-text-faint">
+                  {cert.date}
+                </p>
+              </div>
+            </ScrollReveal>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -3,6 +3,7 @@
 import { motion } from "motion/react";
 import { ChevronDown } from "lucide-react";
 import { AnimatedText } from "@/components/ui/AnimatedText";
+import { FloatingCode } from "@/components/ui/FloatingCode";
 import { GlowBackground } from "@/components/ui/GlowBackground";
 import { MagneticButton } from "@/components/ui/MagneticButton";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
@@ -14,6 +15,7 @@ export function Hero() {
   return (
     <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-(--space-container-x)">
       <GlowBackground />
+      <FloatingCode />
 
       <div className="relative max-w-3xl text-center">
         <p className="mb-6 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">

--- a/src/components/sections/Journey.tsx
+++ b/src/components/sections/Journey.tsx
@@ -1,7 +1,29 @@
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import { experience } from "@/data/experience";
+
 export function Journey() {
   return (
-    <section id="journey" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">Journey</h2>
+    <section id="journey" className="px-(--space-container-x) py-(--space-section-y)">
+      <div className="mx-auto max-w-3xl">
+        <ScrollReveal>
+          <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">Journey</p>
+          <h2 className="mb-10 text-h1 font-semibold">Where I&apos;ve worked</h2>
+        </ScrollReveal>
+        <div className="space-y-8">
+          {experience.map((entry, index) => (
+            <ScrollReveal key={entry.id} delay={index * 0.1}>
+              <div className="border-l-2 border-border pl-6">
+                <p className="mb-1 font-mono text-xs uppercase tracking-[0.08em] text-text-faint">
+                  {entry.period}
+                </p>
+                <h3 className="text-h2 font-semibold">{entry.role}</h3>
+                <p className="mb-2 text-sm text-text-muted">{entry.company}</p>
+                <p className="leading-relaxed text-text-muted">{entry.description}</p>
+              </div>
+            </ScrollReveal>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/sections/Stack.tsx
+++ b/src/components/sections/Stack.tsx
@@ -1,7 +1,48 @@
+import {
+  Atom,
+  Code2,
+  Container,
+  Database,
+  Layers,
+  Palette,
+  Server,
+  type LucideIcon,
+} from "lucide-react";
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import { skills } from "@/data/skills";
+
+const ICONS: Record<string, LucideIcon> = {
+  "code-2": Code2,
+  atom: Atom,
+  layers: Layers,
+  server: Server,
+  database: Database,
+  container: Container,
+  palette: Palette,
+};
+
 export function Stack() {
   return (
-    <section id="stack" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">Stack</h2>
+    <section id="stack" className="px-(--space-container-x) py-(--space-section-y)">
+      <div className="mx-auto max-w-5xl">
+        <ScrollReveal>
+          <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">Stack</p>
+          <h2 className="mb-10 text-h1 font-semibold">What I build with</h2>
+        </ScrollReveal>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+          {skills.map((skill, index) => {
+            const Icon = ICONS[skill.icon];
+            return (
+              <ScrollReveal key={skill.id} delay={index * 0.05}>
+                <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-bg-elevated px-4 py-6 text-center">
+                  {Icon && <Icon size={24} className="text-accent-blue" aria-hidden />}
+                  <span className="text-sm font-medium">{skill.name}</span>
+                </div>
+              </ScrollReveal>
+            );
+          })}
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,7 +1,30 @@
+import { ScrollReveal } from "@/components/ui/ScrollReveal";
+import { testimonials } from "@/data/testimonials";
+
 export function Testimonials() {
   return (
-    <section id="testimonials" className="px-6 py-[var(--space-section-y)]">
-      <h2 className="text-2xl font-semibold">Testimonials</h2>
+    <section id="testimonials" className="px-(--space-container-x) py-(--space-section-y)">
+      <div className="mx-auto max-w-5xl">
+        <ScrollReveal>
+          <p className="mb-4 font-mono text-xs uppercase tracking-[0.08em] text-accent-blue">
+            Testimonials
+          </p>
+          <h2 className="mb-10 text-h1 font-semibold">What people say</h2>
+        </ScrollReveal>
+        <div className="grid gap-6 md:grid-cols-2">
+          {testimonials.map((testimonial, index) => (
+            <ScrollReveal key={testimonial.id} delay={index * 0.1}>
+              <blockquote className="rounded-lg border border-border bg-bg-elevated p-6">
+                <p className="mb-4 leading-relaxed text-text-muted">&ldquo;{testimonial.quote}&rdquo;</p>
+                <footer className="text-sm">
+                  <span className="font-medium">{testimonial.author}</span>
+                  <span className="text-text-faint"> — {testimonial.role}</span>
+                </footer>
+              </blockquote>
+            </ScrollReveal>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/components/ui/CommandPalette.tsx
+++ b/src/components/ui/CommandPalette.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const LINKS = [
+  { href: "#about", label: "About" },
+  { href: "#projects", label: "Projects" },
+  { href: "#stack", label: "Stack" },
+  { href: "#process", label: "Process" },
+  { href: "#github", label: "GitHub" },
+  { href: "#journey", label: "Journey" },
+  { href: "#certifications", label: "Certifications" },
+  { href: "#testimonials", label: "Testimonials" },
+  { href: "#contact", label: "Contact" },
+];
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const router = useRouter();
+
+  function close() {
+    setOpen(false);
+    setQuery("");
+  }
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      } else if (e.key === "Escape") {
+        close();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  if (!open) return null;
+
+  const filtered = LINKS.filter((link) =>
+    link.label.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  function navigateTo(href: string) {
+    router.push(href);
+    close();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 flex items-start justify-center bg-bg/80 px-4 pt-[20vh]"
+      style={{ zIndex: "var(--z-command-palette)" }}
+      onClick={close}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="w-full max-w-md rounded-lg border border-border bg-bg-elevated shadow-glow-sm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+          <Search size={16} className="text-text-faint" aria-hidden />
+          <input
+            autoFocus
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && filtered[0]) {
+                navigateTo(filtered[0].href);
+              }
+            }}
+            placeholder="Jump to a section…"
+            className="w-full bg-transparent text-sm outline-none placeholder:text-text-faint"
+          />
+        </div>
+        <ul className="max-h-80 overflow-y-auto p-2">
+          {filtered.length === 0 && (
+            <li className="px-3 py-2 text-sm text-text-faint">No matches</li>
+          )}
+          {filtered.map((link) => (
+            <li key={link.href}>
+              <button
+                type="button"
+                onClick={() => navigateTo(link.href)}
+                className="block w-full rounded-sm px-3 py-2 text-left text-sm text-text-muted transition-colors hover:bg-bg hover:text-text"
+              >
+                {link.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/FloatingCode.tsx
+++ b/src/components/ui/FloatingCode.tsx
@@ -1,0 +1,23 @@
+const GLYPHS: { text: string; style: React.CSSProperties }[] = [
+  { text: "</>", style: { top: "12%", left: "8%", animationDuration: "7s" } },
+  { text: "{ }", style: { top: "70%", left: "12%", animationDuration: "9s", animationDelay: "1s" } },
+  { text: "=>", style: { top: "22%", right: "10%", animationDuration: "8s", animationDelay: "0.5s" } },
+  { text: "const", style: { top: "60%", right: "6%", animationDuration: "10s", animationDelay: "2s" } },
+  { text: "npm i", style: { top: "85%", left: "45%", animationDuration: "6s", animationDelay: "1.5s" } },
+];
+
+export function FloatingCode() {
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
+      {GLYPHS.map((glyph) => (
+        <span
+          key={glyph.text}
+          className="animate-float absolute select-none font-mono text-xs text-text-faint/30 md:text-sm"
+          style={glyph.style}
+        >
+          {glyph.text}
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Wires the four remaining heading-only section stubs to the typed data
layer (ScrollReveal-staggered grids/lists), and adds the two primitives
named in docs/MILESTONES.md for this milestone: CommandPalette
(Ctrl/Cmd+K, plain filter + next/navigation) and FloatingCode (CSS-only
@keyframes float, reduced-motion aware). Richer per-section treatments
(SVG diagram, timeline, hover-flip, carousel, fuzzy search, animated
open/close) stay deferred to Phase 2 per docs/SRS.md.

Addresses #24, #25, #26, #27, #28, #29 (closed post-merge per CLAUDE.md's
status-update convention, not by this commit).