### PR TITLE
M3: Responsive, reduced-motion, performance, and SEO polish

### DIFF
--- a/src/app/apple-icon.tsx
+++ b/src/app/apple-icon.tsx
@@ -1,0 +1,34 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: "45px",
+          background: "linear-gradient(135deg, #6366f1 0%, #38bdf8 100%)",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: 70,
+            fontWeight: 600,
+            color: "#050505",
+          }}
+        >
+          PK
+        </span>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,20 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          borderRadius: "8px",
+          background: "linear-gradient(135deg, #6366f1 0%, #38bdf8 100%)",
+        }}
+      />
+    ),
+    { ...size },
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,9 +19,26 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const TITLE = "Pravin K — Full Stack Developer";
+const DESCRIPTION =
+  "Portfolio of Pravin K, a full stack developer building fast, thoughtful products with Next.js, TypeScript & Node.js.";
+
 export const metadata: Metadata = {
-  title: "Pravin K — Full Stack Developer",
-  description: "Portfolio of Pravin K, a full stack developer building fast, thoughtful products with Next.js, TypeScript & Node.js.",
+  metadataBase: new URL("https://pravin671231.dev"),
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/",
+    siteName: "Pravin K — Portfolio",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: DESCRIPTION,
+  },
 };
 
 export default function RootLayout({ children }: LayoutProps<"/">) {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,85 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          position: "relative",
+          background: "#050505",
+          padding: "0 96px",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: -180,
+            left: -180,
+            width: 560,
+            height: 560,
+            borderRadius: "50%",
+            background: "#6366f1",
+            opacity: 0.22,
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: -200,
+            right: -160,
+            width: 600,
+            height: 600,
+            borderRadius: "50%",
+            background: "#38bdf8",
+            opacity: 0.2,
+          }}
+        />
+        <span
+          style={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: 22,
+            letterSpacing: 4,
+            color: "#6366f1",
+            marginBottom: 24,
+          }}
+        >
+          PRAVIN K
+        </span>
+        <span
+          style={{
+            fontSize: 64,
+            fontWeight: 600,
+            color: "#f5f5f7",
+            marginBottom: 20,
+          }}
+        >
+          Full Stack Developer
+        </span>
+        <span style={{ fontSize: 28, color: "#9a9aa2" }}>
+          Building fast, thoughtful products with Next.js &amp; TypeScript.
+        </span>
+        <span
+          style={{
+            position: "absolute",
+            bottom: 40,
+            right: 64,
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: 20,
+            color: "#5c5c64",
+          }}
+        >
+          pravin671231.dev
+        </span>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/components/sections/Github.tsx
+++ b/src/components/sections/Github.tsx
@@ -3,6 +3,7 @@
 import { animate, motion, useInView, useMotionValue, type Variants } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { useCursor } from "@/context/CursorContext";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { fetchGithubStats } from "@/lib/github";
 
 const GITHUB_USER = "Pravin671231";
@@ -40,22 +41,25 @@ function CountUp({ value, label }: { value: number; label: string }) {
   const ref = useRef<HTMLParagraphElement>(null);
   const inView = useInView(ref, { once: true, amount: 0.5 });
   const motionValue = useMotionValue(0);
+  const prefersReducedMotion = useReducedMotion();
   const [display, setDisplay] = useState("00");
 
   useEffect(() => {
-    if (!inView) return;
+    if (!inView || prefersReducedMotion) return;
     const controls = animate(motionValue, value, {
       duration: 1.2,
       ease: "easeOut",
       onUpdate: (v) => setDisplay(String(Math.round(v)).padStart(2, "0")),
     });
     return () => controls.stop();
-  }, [inView, value, motionValue]);
+  }, [inView, value, motionValue, prefersReducedMotion]);
+
+  const shown = inView && prefersReducedMotion ? String(value).padStart(2, "0") : display;
 
   return (
     <div>
       <p ref={ref} className="font-mono text-4xl font-semibold">
-        {display}
+        {shown}
       </p>
       <p className="mt-2 text-sm text-text-muted">{label}</p>
     </div>
@@ -65,6 +69,7 @@ function CountUp({ value, label }: { value: number; label: string }) {
 export function Github() {
   const [stats, setStats] = useState({ repos: 0, followers: 0, totalStars: 0 });
   const { setCursor } = useCursor();
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
     fetchGithubStats().then(setStats);
@@ -95,8 +100,8 @@ export function Github() {
         <motion.div
           className="mx-auto grid max-w-xl gap-1"
           style={{ gridTemplateColumns: "repeat(20, minmax(0,1fr))" }}
-          initial="hidden"
-          whileInView="visible"
+          initial={prefersReducedMotion ? "visible" : "hidden"}
+          whileInView={prefersReducedMotion ? undefined : "visible"}
           viewport={{ once: true, amount: 0.3 }}
           variants={gridContainerVariants}
         >


### PR DESCRIPTION
Wraps up Milestone M3 (issues #30–#34) — audit-and-fix passes across the app plus SEO polish.

**Reduced-motion (#31):** `Github.tsx`'s `CountUp` and contribution-grid stagger were the one animated section not gated on `useReducedMotion()` — fixed to render final values/state instantly. Verified via Playwright (emulated reduced-motion, every section, route nav to a case study and back) that no console errors occur and every other system already collapses correctly (`ScrollReveal`, `FloatingCode`, `CustomCursor`, `Process`/`Projects` GSAP cleanup via `gsap.context().revert()`).

**Responsive (#30):** verified 375/768/1440 widths — zero horizontal overflow, Projects' pinned-scroll vs. vertical-stack fallback and CustomCursor's touch fallback both switch correctly, CommandPalette fits at narrow widths. No fixes needed.

**Performance (#32):** Lighthouse against a production build shows CLS 0 (image sizing already correct) and no scroll jank during Hero/Projects pinned scroll. Performance score is held back by client-JS hydration cost (GSAP + Lenis + Motion) — an architectural tradeoff of this MVP's animation stack rather than a quick fix, documented rather than addressed here.

**SEO/metadata (#34):** added OpenGraph/Twitter metadata and `metadataBase` to `layout.tsx`, plus `app/icon.tsx`, `app/apple-icon.tsx`, and `app/opengraph-image.tsx` (`next/og` `ImageResponse`) matching the monogram and social-share mockups in `brand-kit/index.html`.

**Build/lint (#33):** `npm run lint` and `npm run build` both clean after all changes above.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G6rtwnbwe3XBBvmuffM81)_